### PR TITLE
Upgrade yada to 1.1.29.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [bidi "2.0.9"]      ; routing
                  [aleph "0.4.1"] ; server
                  [aleph-middleware "0.1.1"]
-                 [yada "1.1.26"]
+                 [yada "1.1.29"]
                  
                  [trptcolin/versioneer "0.2.0"]
                  


### PR DESCRIPTION
Fixes a `ClassNotFoundException` with `leiningen 2.7.1` and
`java 1.8.0_77`.

This is a super useful tool by the way. Thanks!